### PR TITLE
Update sbt-slamdata plugin to 3.0.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ resolvers += Resolver.bintrayRepo("slamdata-inc", "maven-public")
 
 addSbtPlugin("com.eed3si9n"    % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin("io.get-coursier" % "sbt-coursier"  % "1.1.0-M7")
-addSbtPlugin("com.slamdata"    % "sbt-slamdata"  % "1.4.0")
+addSbtPlugin("com.slamdata"    % "sbt-slamdata"  % "3.0.0")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -2,4 +2,4 @@ resolvers += Resolver.sonatypeRepo("releases")
 resolvers += Resolver.bintrayRepo("slamdata-inc", "maven-public")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M4")
-addSbtPlugin("com.slamdata"    % "sbt-slamdata" % "1.4.0")
+addSbtPlugin("com.slamdata"    % "sbt-slamdata" % "3.0.0")

--- a/src/main/scala/quasar/sbtdatasource/AssemblePlugin.scala
+++ b/src/main/scala/quasar/sbtdatasource/AssemblePlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2018 SlamData Inc.
+ * Copyright 2014–2019 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/quasar/sbtdatasource/DatasourcePlugin.scala
+++ b/src/main/scala/quasar/sbtdatasource/DatasourcePlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2018 SlamData Inc.
+ * Copyright 2014–2019 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Necessary because the current sbt-slamdata prevents publishing (because it requires oraclejdk)