### PR TITLE
Add support for specifying extra Maven repositories

### DIFF
--- a/src/main/scala/quasar/sbt/AssemblePlugin.scala
+++ b/src/main/scala/quasar/sbt/AssemblePlugin.scala
@@ -62,7 +62,8 @@ object AssemblePlugin {
       dsJar: Path,
       quasarVersion: String,
       scalaBinaryVersion: String,
-      dstDir: Path)(
+      dstDir: Path,
+      extraResolvers: Seq[MavenRepository])(
       implicit P: Parallel[F, G])
       : F[Path] = {
 
@@ -118,7 +119,7 @@ object AssemblePlugin {
           ResolutionProcess.fetch(
             Seq(
               MavenRepository("https://repo1.maven.org/maven2"),
-              MavenRepository("https://dl.bintray.com/slamdata-inc/maven-public")),
+              MavenRepository("https://dl.bintray.com/slamdata-inc/maven-public")) ++ extraResolvers,
             cache))
 
         // fetch artifacts in parallel into cache

--- a/src/main/scala/quasar/sbt/QuasarPlugin.scala
+++ b/src/main/scala/quasar/sbt/QuasarPlugin.scala
@@ -22,6 +22,7 @@ import scala.collection.Seq
 import scala.concurrent.ExecutionContext
 
 import cats.effect.IO
+import coursier.MavenRepository
 import coursier.interop.cats._
 import sbt._, Keys._
 
@@ -36,6 +37,7 @@ object QuasarPlugin extends AutoPlugin {
     val quasarPluginDatasourceFqcn: SettingKey[Option[String]] = settingKey[Option[String]]("The fully qualified class name of the datasource module.")
     val quasarPluginDestinationFqcn: SettingKey[Option[String]] = settingKey[Option[String]]("The fully qualified class name of the destination module.")
     val quasarPluginQuasarVersion: SettingKey[String] = settingKey[String]("Defines the version of Quasar to depend on.")
+    val quasarPluginExtraResolvers: SettingKey[Seq[MavenRepository]] = settingKey[Seq[MavenRepository]]("Extra resolvers to use when assembling plugin.")
 
     val quasarPluginAssemble: TaskKey[File] = taskKey[File]("Produces the tarball containing the quasar plugin and all non-quasar dependencies.")
   }
@@ -54,6 +56,8 @@ object QuasarPlugin extends AutoPlugin {
       quasarPluginDatasourceFqcn := None,
 
       quasarPluginDestinationFqcn := None,
+
+      quasarPluginExtraResolvers := Seq.empty,
 
       libraryDependencies := {
         val quasarDependencies =
@@ -84,7 +88,8 @@ object QuasarPlugin extends AutoPlugin {
             (Keys.`package` in Compile).value.toPath,
             quasarPluginQuasarVersion.value,
             (scalaBinaryVersion in Compile).value,
-            (crossTarget in Compile).value.toPath)
+            (crossTarget in Compile).value.toPath,
+            quasarPluginExtraResolvers.value)
 
         pluginPath.map(_.toFile).unsafeRunSync()
       })


### PR DESCRIPTION
Not strictly necesary, but `quasarPluginAssemble` doesn't work without this since Amazon hosts its own Maven things [ch10385]